### PR TITLE
Add unclassified road filter to straight-way analysis

### DIFF
--- a/housenumber8_and_straight_ways.py
+++ b/housenumber8_and_straight_ways.py
@@ -128,6 +128,7 @@ def main() -> None:
         args.access,
         include_primary=not args.no_primary,
         include_secondary=not args.no_secondary,
+        only_unclassified=True,
     )
     collector.apply_file(str(pbf), locations=True)
     segments = extract_straight_sections(

--- a/tests/test_find_straight_ways_v06.py
+++ b/tests/test_find_straight_ways_v06.py
@@ -1,0 +1,28 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_only_unclassified() -> None:
+    pbf = Path(__file__).resolve().parent.parent / "pbf" / "bremen-latest.osm.pbf"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "find_straight_ways_v06.py",
+            str(pbf),
+            "--min-length",
+            "1000",
+            "--min-straightness",
+            "0.999",
+            "--top",
+            "5",
+            "--only-unclassified",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    lines = [line for line in result.stdout.splitlines() if line.startswith("Segment")]
+    assert lines, "No segments returned"
+    assert all("(unclassified)" in line for line in lines)
+


### PR DESCRIPTION
## Summary
- allow `find_straight_ways_v06.py` to filter ways by `highway=unclassified`
- ensure combined housenumber/straight-way script only inspects unclassified roads
- add regression test for new `--only-unclassified` flag

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3115ed3788327b47d58f57ac50b19