### PR TITLE
Sort farthest buildings by distance

### DIFF
--- a/lonely/find_farthest_buildings.py
+++ b/lonely/find_farthest_buildings.py
@@ -89,7 +89,8 @@ def compute_lonely_buildings(geojson_path, limit=1):
         d = haversine_m(lon, lat, lon1, lat1)
         results.append((osm_id, nn_osm_id, d, lon, lat))
 
-    results.sort(key=lambda x: x[1], reverse=True)
+    # Sortieren nach Abstand in Metern, nicht nach OSM-ID
+    results.sort(key=lambda x: x[2], reverse=True)
     return results[:limit]
 
 


### PR DESCRIPTION
## Summary
- sort lonely building results by distance instead of nearest neighbor ID

## Testing
- `python -m py_compile lonely/find_farthest_buildings.py`
- `python3 lonely/find_farthest_buildings.py --pbf pbf/bremen-latest.osm.pbf --out out/bremen_farthest --limit 5`

------
https://chatgpt.com/codex/tasks/task_e_68a9a2f723d88327b058a88a4084a760