### PR TITLE
Exclude huts and cabins from smallest building search

### DIFF
--- a/smallest/find_smallest_buildings.py
+++ b/smallest/find_smallest_buildings.py
@@ -59,7 +59,7 @@ if osmium is not None:
             building = w.tags.get("building")
             if not building or not hn:
                 return
-            if building == "allotment_house" or w.tags.get("power") == "substation":
+            if building in {"allotment_house", "hut", "cabin"} or w.tags.get("power") == "substation":
                 return
             if len(w.nodes) < 3:
                 return


### PR DESCRIPTION
## Summary
- ignore buildings tagged `building=hut` or `building=cabin` when collecting smallest buildings

## Testing
- `python -m py_compile smallest/find_smallest_buildings.py`
- `python smallest/find_smallest_buildings.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae5d3f6083279a1cc6cc4858c83e