### PR TITLE
Fix freestanding building detection

### DIFF
--- a/smallest/find_smallest_buildings.py
+++ b/smallest/find_smallest_buildings.py
@@ -97,12 +97,12 @@ def main() -> None:
 
     node_usage: Dict[int, int] = {}
     for _, _, node_ids in collector.buildings:
-        for nid in node_ids:
+        for nid in set(node_ids):
             node_usage[nid] = node_usage.get(nid, 0) + 1
 
     freestanding: List[Tuple[int, List[Coord]]] = []
     for bid, coords, node_ids in collector.buildings:
-        if all(node_usage[nid] == 1 for nid in node_ids):
+        if all(node_usage[nid] == 1 for nid in set(node_ids)):
             freestanding.append((bid, coords))
 
     items = []


### PR DESCRIPTION
## Summary
- ensure each node is counted only once when tallying building node usage
- correctly detect and report freestanding buildings with house numbers

## Testing
- `python -m py_compile smallest/find_smallest_buildings.py`
- `python smallest/find_smallest_buildings.py pbf/bremen-latest.osm.pbf --limit 1`


------
https://chatgpt.com/codex/tasks/task_e_68b0c53c8ef88327820e990b888770df